### PR TITLE
Closer API to Ember

### DIFF
--- a/addon/-private/query-params-builder.js
+++ b/addon/-private/query-params-builder.js
@@ -84,7 +84,7 @@ export default class QueryParamsBuilder {
     // Create the `key` to `name` mapping used by Ember to register the QPs
     let queryParamsMap = keys(queryParams).reduce((qps, key) => {
       qps[key] = {
-        as: queryParams[key].as || key,
+        as: queryParams[key].as,
         scope: queryParams[key].scope
       };
 

--- a/addon/-private/query-params-builder.js
+++ b/addon/-private/query-params-builder.js
@@ -15,39 +15,69 @@ const {
 } = Object;
 
 export default class QueryParamsBuilder {
-  constructor(queryParams = {}) {
-    assert('[ember-parachute] You cannot pass an empty object to the query params builder.', queryParams && !isEmpty(keys(queryParams)));
+  /**
+   * @method constructor
+   * @constructor
+   * @public
+   * @param  {...Object} queryParams
+   */
+  constructor() {
+    let queryParams = assign({}, ...arguments);
+
+    assert('[ember-parachute] You cannot pass an empty object to the QueryParamsBuilder.', queryParams && !isEmpty(keys(queryParams)));
 
     this._queryParams = queryParams;
     this.queryParams = this._normalizeQueryParams(queryParams);
     this.Mixin = this._generateMixin();
   }
 
+  /**
+   * Extend this QueryParamsBuilder with the passed query paramaters
+   *
+   * @method extend
+   * @public
+   * @param  {...Object} queryParams
+   */
   extend() {
-    return new QueryParamsBuilder(assign({}, this._queryParams, ...arguments));
+    return new QueryParamsBuilder(this._queryParams, ...arguments);
   }
 
+  /**
+   * Normalize the passed queryParams object and assign each key some
+   * defaults.
+   *
+   * @method _normalizeQueryParams
+   * @private
+   * @param  {Object} queryParams
+   * @return {Object}
+   */
   _normalizeQueryParams(queryParams) {
     return keys(queryParams).reduce((o, key) => {
       let queryParam = queryParams[key];
-      let defaults = {
-        key,
-        name: key,
-        refresh: false,
-        value(controller) {
-          let value = get(controller, this.key);
-          return (typeof this.normalize === 'function') ? this.normalize(value) : value;
-        }
-      };
 
-      assert(`[ember-parachute] The query paramater ${key} must specify an object.`, queryParam && typeof queryParam === 'object');
-
-      o[key] = assign(defaults, queryParam);
+      if (queryParam && typeof queryParam === 'object') {
+        o[key] = assign({
+          key,
+          name: key,
+          refresh: false,
+          value(controller) {
+            let value = get(controller, this.key);
+            return (typeof this.normalize === 'function') ? this.normalize(value) : value;
+          }
+        }, queryParam);
+      }
 
       return o;
     }, {});
   }
 
+  /**
+   * Generate a Mixin from this instance's queryParams
+   *
+   * @method _generateMixin
+   * @private
+   * @return {Ember.Mixin}
+   */
   _generateMixin() {
     let queryParams = this.queryParams;
 

--- a/addon/-private/query-params-builder.js
+++ b/addon/-private/query-params-builder.js
@@ -58,7 +58,7 @@ export default class QueryParamsBuilder {
       if (queryParam && typeof queryParam === 'object') {
         o[key] = assign({
           key,
-          name: key,
+          as: key,
           refresh: false,
           value(controller) {
             let value = get(controller, this.key);
@@ -83,7 +83,11 @@ export default class QueryParamsBuilder {
 
     // Create the `key` to `name` mapping used by Ember to register the QPs
     let queryParamsMap = keys(queryParams).reduce((qps, key) => {
-      qps[key] = queryParams[key].name || key;
+      qps[key] = {
+        as: queryParams[key].as || key,
+        scope: queryParams[key].scope
+      };
+
       return qps;
     }, {});
 

--- a/addon/index.js
+++ b/addon/index.js
@@ -1,8 +1,4 @@
 import QueryParamsBuilder from './-private/query-params-builder';
 import Transforms from './-private/transforms';
 
-function buildQueryParams(options = {}) {
-  return new QueryParamsBuilder(options);
-}
-
-export { buildQueryParams, Transforms };
+export { QueryParamsBuilder, Transforms };

--- a/addon/services/qp.js
+++ b/addon/services/qp.js
@@ -65,7 +65,7 @@ export default Ember.Service.extend({
    * @method resetParams
    * @public
    * @param  {String} routeName
-   * @param  {...string} params
+   * @param  {...String} params
    */
   resetParams(routeName, ...params) {
     let { controller, queryParamsArray } = this.cacheFor(routeName);

--- a/addon/services/qp.js
+++ b/addon/services/qp.js
@@ -143,15 +143,16 @@ export default Ember.Service.extend({
   _scheduleChangeEvent(routeName, changes = {}, present = {}) {
     run.schedule('afterRender', () => {
       let { controller, queryParamsArray } = this.cacheFor(routeName);
-      let changedKeys = keys(changes);
+      let changed = normalizeNamedParams(changes, queryParamsArray);
+      let changedKeys = keys(changed);
 
       let objToPass = {
         routeName,
-        changed: normalizeNamedParams(changes, queryParamsArray),
+        changed,
         present: normalizeNamedParams(present, queryParamsArray),
         queryParams: this.queryParamsFor(routeName),
         shouldRefresh: queryParamsArray.any((qp) => {
-          return changedKeys.indexOf(qp.name) > -1 && qp.refresh;
+          return changedKeys.indexOf(qp.key) > -1 && qp.refresh;
         })
       };
 

--- a/addon/services/qp.js
+++ b/addon/services/qp.js
@@ -142,18 +142,15 @@ export default Ember.Service.extend({
    */
   _scheduleChangeEvent(routeName, changes = {}, present = {}) {
     run.schedule('afterRender', () => {
-      let { controller, queryParamsArray } = this.cacheFor(routeName);
+      let { controller, queryParams, queryParamsArray } = this.cacheFor(routeName);
       let changed = normalizeNamedParams(changes, queryParamsArray);
-      let changedKeys = keys(changed);
 
       let objToPass = {
         routeName,
         changed,
         present: normalizeNamedParams(present, queryParamsArray),
         queryParams: this.queryParamsFor(routeName),
-        shouldRefresh: queryParamsArray.any((qp) => {
-          return changedKeys.indexOf(qp.key) > -1 && qp.refresh;
-        })
+        shouldRefresh: emberArray(keys(changed)).any((key) => queryParams[key].refresh)
       };
 
       tryInvoke(controller, 'queryParamsDidChange', [ objToPass ]);

--- a/addon/utils/normalized-named-params.js
+++ b/addon/utils/normalized-named-params.js
@@ -12,9 +12,9 @@
  * @return {Object}
  */
  export default function normalizeNamedParams(o, qp) {
-   return qp.reduce((ko, data) => {
-     if (o[data.name]) {
-       ko[data.key] = o[data.name];
+   return qp.reduce((ko, p) => {
+     if (o[p.as]) {
+       ko[p.key] = o[p.as];
      }
      return ko;
    }, {});

--- a/tests/dummy/app/controllers/index.js
+++ b/tests/dummy/app/controllers/index.js
@@ -3,7 +3,7 @@ import { QueryParamsBuilder, Transforms } from 'ember-parachute';
 
 const QueryParams = new QueryParamsBuilder({
   direction: {
-    name: 'dir',
+    as: 'dir',
     defaultValue: 'asc',
     normalize: Transforms.String,
     refresh: true

--- a/tests/dummy/app/controllers/index.js
+++ b/tests/dummy/app/controllers/index.js
@@ -1,7 +1,7 @@
 import Ember from 'ember';
-import { buildQueryParams, Transforms } from 'ember-parachute';
+import { QueryParamsBuilder, Transforms } from 'ember-parachute';
 
-const QueryParams = buildQueryParams({
+const QueryParams = new QueryParamsBuilder({
   direction: {
     name: 'dir',
     defaultValue: 'asc',

--- a/tests/integration/services/qp-test.js
+++ b/tests/integration/services/qp-test.js
@@ -1,6 +1,6 @@
 import Ember from 'ember';
 import { moduleFor, test } from 'ember-qunit';
-import { buildQueryParams, Transforms } from 'ember-parachute';
+import { QueryParamsBuilder, Transforms } from 'ember-parachute';
 
 const {
   on,
@@ -8,7 +8,7 @@ const {
   assign
 } = Ember;
 
-const QueryParams = buildQueryParams({
+const QueryParams = new QueryParamsBuilder({
   direction: {
     name: 'dir',
     defaultValue: 'asc',

--- a/tests/integration/services/qp-test.js
+++ b/tests/integration/services/qp-test.js
@@ -10,7 +10,7 @@ const {
 
 const QueryParams = new QueryParamsBuilder({
   direction: {
-    name: 'dir',
+    as: 'dir',
     defaultValue: 'asc',
     normalize: Transforms.String,
     refresh: true

--- a/tests/unit/query-params-builder-test.js
+++ b/tests/unit/query-params-builder-test.js
@@ -11,7 +11,17 @@ test('asserts', function(assert) {
   assert.expect(2);
 
   assert.throws(() => new QueryParamsBuilder());
-  assert.throws(() => new QueryParamsBuilder({ foo: true }));
+  assert.throws(() => new QueryParamsBuilder({}, {}, {}));
+});
+
+test('create', function(assert) {
+  assert.expect(2);
+
+  let builder = new QueryParamsBuilder({ foo: {} }, { bar: {} }, { baz: 1 });
+  let builder2 = new QueryParamsBuilder({ foo: {} }, { bar: {} }, { bar: undefined });
+
+  assert.deepEqual(keys(builder.queryParams), ['foo', 'bar']);
+  assert.deepEqual(keys(builder2.queryParams), ['foo']);
 });
 
 test('extend', function(assert) {

--- a/tests/unit/query-params-builder-test.js
+++ b/tests/unit/query-params-builder-test.js
@@ -38,15 +38,15 @@ test('QP Normalization', function(assert) {
 
   let builder = new QueryParamsBuilder({
     foo: {},
-    bar: { name: '_bar_' }
+    bar: { as: '_bar_' }
   });
 
   let { queryParams } = builder;
 
   assert.equal(queryParams.foo.key, 'foo');
-  assert.equal(queryParams.foo.name, 'foo');
+  assert.equal(queryParams.foo.as, 'foo');
   assert.equal(typeof queryParams.foo.value, 'function');
 
   assert.equal(queryParams.bar.key, 'bar');
-  assert.equal(queryParams.bar.name, '_bar_');
+  assert.equal(queryParams.bar.as, '_bar_');
 });


### PR DESCRIPTION
1. Replace `buildQueryParams` with `new QueryParamsBuilder`.
2. Allow constructor to accept multiple arguments to simulate `Mixins`

```js
const QueryParams = new QueryParamsBuilder(SortParams, FilterParams, {
  foo: {}
});

const QueryParams_2 = QueryParams.extend({
  bar: {}
});
```

3. Closer API to Ember QP Declaration (+ support `scope`)

```js
const QueryParams = new QueryParamsBuilder({
  foo: {
    as: 'bar',
    scope: 'controller'
  }
});
```

From [Routing: Query Params](https://guides.emberjs.com/v2.12.0/routing/query-params/):

```js
import Ember from 'ember';

export default Ember.Controller.extend({
  queryParams: ['page', 'filter',
    {
      showMagnifyingGlass: {
        scope: 'controller',
        as: 'glass'
      }
    }
  ]
});
```