### PR TITLE
Use controller class `proto` instead of creating it if not available

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,6 +38,7 @@ before_install:
 
 install:
   - yarn install --no-lockfile
+  - npm rebuild node-sass
 
 script:
   # Usually, it's ok to finish the test scenario without reverting

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,6 +38,8 @@ before_install:
 
 install:
   - yarn install --no-lockfile
+
+before_script:
   - npm rebuild node-sass
 
 script:

--- a/addon/instance-initializers/ember-parachute.js
+++ b/addon/instance-initializers/ember-parachute.js
@@ -13,27 +13,6 @@ const {
 
 export function initialize(/* application */) {
   Ember.Route.reopen({
-    actions: {
-      /**
-       * Route hook that fires when query params are changed.
-       *
-       * @public
-       * @param {object} [changed={}]
-       * @param {object} [present={}]
-       * @param {object} [removed={}]
-       * @returns {any}
-       */
-      queryParamsDidChange(changed = {}, present = {}, removed = {}) {
-        let { controller, routeName } = this;
-
-        if (QueryParams.hasParachute(controller)) {
-          this._scheduleParachuteChangeEvent(routeName, controller, assign({}, changed, removed));
-        }
-
-        return this._super(...arguments);
-      }
-    },
-
     /**
      * Serialize query param value if a given query param has a `serialize`
      * method.
@@ -96,6 +75,27 @@ export function initialize(/* application */) {
         tryInvoke(controller, 'queryParamsDidChange', [changeEvent]);
         sendEvent(controller, 'queryParamsDidChange', [changeEvent]);
       });
+    },
+
+    actions: {
+      /**
+       * Route hook that fires when query params are changed.
+       *
+       * @public
+       * @param {object} [changed={}]
+       * @param {object} [present={}]
+       * @param {object} [removed={}]
+       * @returns {any}
+       */
+      queryParamsDidChange(changed = {}, present = {}, removed = {}) {
+        let { controller, routeName } = this;
+
+        if (QueryParams.hasParachute(controller)) {
+          this._scheduleParachuteChangeEvent(routeName, controller, assign({}, changed, removed));
+        }
+
+        return this._super(...arguments);
+      }
     }
   });
 }

--- a/addon/utils/lookup-controller.js
+++ b/addon/utils/lookup-controller.js
@@ -11,5 +11,12 @@ const { get, getOwner } = Ember;
  * @returns {Ember.Controller}
  */
 export default function lookupController(route, ownerLookupFn = getOwner) {
-  return route.controller || ownerLookupFn(route).lookup(`controller:${get(route, 'routeName')}`);
+  let controller = get(route, 'controller');
+
+  if (!controller) {
+    let factory = ownerLookupFn(route).factoryFor(`controller:${get(route, 'routeName')}`);
+    return factory.class.proto();
+  }
+
+  return controller;
 }

--- a/addon/utils/lookup-controller.js
+++ b/addon/utils/lookup-controller.js
@@ -14,6 +14,12 @@ export default function lookupController(route, ownerLookupFn = getOwner) {
   let controller = get(route, 'controller');
 
   if (!controller) {
+    /**
+     * If the controller doesnt exist, use the class proto instead. Before, we
+     * would create the controller if it didnt exist which caused a lot of issues
+     * (especially with authentication) due to the controller being created
+     * prematurely.
+     */
     let factory = ownerLookupFn(route).factoryFor(`controller:${get(route, 'routeName')}`);
     return factory.class.proto();
   }

--- a/tests/unit/utils/lookup-controller-test.js
+++ b/tests/unit/utils/lookup-controller-test.js
@@ -4,15 +4,20 @@ import { module, test } from 'qunit';
 
 module('Unit | Utility | lookup controller');
 
+const Controller = Ember.Controller.extend({
+  parachuteController: true
+})
+
 const dummyRoute = {
-  controller: Ember.Controller.create()
+  controller: Controller.create()
 }
 
 function dummyLookup() {
   return {
     factoryFor() {
       return {
-        class: Ember.Controller
+        create: () => Controller.create(),
+        class: Controller
       };
     }
   };
@@ -20,10 +25,10 @@ function dummyLookup() {
 
 test('it looks up the controller from a route', function(assert) {
   let result = lookupController(dummyRoute);
-  assert.equal(result, dummyRoute.controller);
+  assert.ok(result.parachuteController);
 });
 
 test('it looks up the controller from a route owner if route controller is not defined', function(assert) {
   let result = lookupController({}, dummyLookup);
-  assert.ok(result.isController);
+  assert.ok(result.parachuteController);
 });

--- a/tests/unit/utils/lookup-controller-test.js
+++ b/tests/unit/utils/lookup-controller-test.js
@@ -1,22 +1,26 @@
+import Ember from 'ember';
 import lookupController from 'ember-parachute/utils/lookup-controller';
 import { module, test } from 'qunit';
 
 module('Unit | Utility | lookup controller');
 
 const dummyRoute = {
-  controller: { isController: true }
+  controller: Ember.Controller.create()
 }
+
 function dummyLookup() {
   return {
-    lookup() {
-      return { isController: true };
+    factoryFor() {
+      return {
+        class: Ember.Controller
+      };
     }
   };
 }
 
 test('it looks up the controller from a route', function(assert) {
   let result = lookupController(dummyRoute);
-  assert.ok(result.isController);
+  assert.equal(result, dummyRoute.controller);
 });
 
 test('it looks up the controller from a route owner if route controller is not defined', function(assert) {


### PR DESCRIPTION
This fix prevents us from creating the controller prematurely when it is not found which has some unexpected behaviors.

Note: This fix is backwards compatible and is used internally in the ember-route to do same thing. 