### PR TITLE
Bump ember-getowner-polyfill to v2.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "dependencies": {
     "ember-assign-polyfill": "^2.0.1",
     "ember-cli-babel": "^6.0.0",
-    "ember-getowner-polyfill": "^1.2.3"
+    "ember-getowner-polyfill": "^2.0.1"
   },
   "devDependencies": {
     "@types/ember": "^2.7.40",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2502,11 +2502,18 @@ ember-getowner-polyfill@1.1.1:
     ember-cli-babel "^5.1.6"
     ember-cli-version-checker "^1.2.0"
 
-ember-getowner-polyfill@^1.1.0, ember-getowner-polyfill@^1.2.3:
+ember-getowner-polyfill@^1.1.0:
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/ember-getowner-polyfill/-/ember-getowner-polyfill-1.2.3.tgz#ea70f4a48b1c05b91056371d1878bbafe018222e"
   dependencies:
     ember-cli-babel "^5.1.6"
+    ember-cli-version-checker "^1.2.0"
+    ember-factory-for-polyfill "^1.1.0"
+
+ember-getowner-polyfill@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/ember-getowner-polyfill/-/ember-getowner-polyfill-2.0.1.tgz#9bfe2b4d527ed174e76fef2c8f30937d77cb66fb"
+  dependencies:
     ember-cli-version-checker "^1.2.0"
     ember-factory-for-polyfill "^1.1.0"
 


### PR DESCRIPTION
Updates ember-getowner-polyfill to v2.0.1

Note: This isn't needed if https://github.com/offirgolan/ember-parachute/pull/38 is merged