### PR TITLE
Prevent multiple initializations

### DIFF
--- a/addon/initializers/ember-parachute.js
+++ b/addon/initializers/ember-parachute.js
@@ -16,6 +16,10 @@ const {
 } = Object;
 
 export function initialize(/* application */) {
+  if (Ember.Route._didInitializeParachute) {
+    return;
+  }
+
   Ember.Route.reopen({
     /**
      * Setup the route's `queryParams` map and call the `setup` hook
@@ -176,6 +180,8 @@ export function initialize(/* application */) {
       }
     }
   });
+
+  Ember.Route.reopenClass({ _didInitializeParachute: true })
 }
 
 export default {


### PR DESCRIPTION
Somehow the initializer ran twice in some of my acceptance tests which caused the controller hooks to be fired multiple times. This fix should prevent it from reopening the route more than once.

This may also fix #39 