### PR TITLE
add serialized information to queryParamsState

### DIFF
--- a/addon/-private/state.js
+++ b/addon/-private/state.js
@@ -3,7 +3,8 @@ import Ember from 'ember';
 
 const {
   assert,
-  isPresent
+  isPresent,
+  canInvoke
 } = Ember;
 
 /**
@@ -16,8 +17,12 @@ const {
 function queryParamsState(queryParamsArray, controller) {
   return queryParamsArray.reduce((state, qp) => {
     let value = qp.value(controller);
+    let serializedValue = canInvoke(qp, 'serialize') ? qp.serialize(value) : value;
+    let as = qp.as || qp.key;
     state[qp.key] = {
       value,
+      serializedValue,
+      as,
       defaultValue: qp.defaultValue,
       changed: JSON.stringify(value) !== JSON.stringify(qp.defaultValue)
     };

--- a/tests/unit/query-params-test.js
+++ b/tests/unit/query-params-test.js
@@ -23,13 +23,24 @@ const queryParams = new QueryParams({
   search: {
     defaultValue: '',
     refresh: true
+  },
+  colors: {
+    defaultValue: [],
+    refresh: true,
+    serialize(value) {
+      return value.toString();
+    },
+    deserialize(value = '') {
+      return value.split(',');
+    }
   }
 });
 
 const defaultValues = {
   direction: 'asc',
   page: 1,
-  search: ''
+  search: '',
+  colors: []
 }
 
 const Controller = Ember.Object.extend(queryParams.Mixin);
@@ -139,7 +150,8 @@ test('CP - allQueryParams', function(assert) {
   assert.deepEqual(controller.get('allQueryParams'), {
     direction: 'asc',
     page: 1,
-    search: ''
+    search: '',
+    colors: []
   });
 
   controller.set('page', 2);
@@ -147,17 +159,20 @@ test('CP - allQueryParams', function(assert) {
   assert.deepEqual(controller.get('allQueryParams'), {
     direction: 'asc',
     page: 2,
-    search: ''
+    search: '',
+    colors: []
   });
 });
 
 test('CP - queryParamsState', function(assert) {
-  assert.expect(3);
+  assert.expect(4);
 
   assert.deepEqual(controller.get('queryParamsState.page'), {
     value: 1,
     defaultValue: 1,
-    changed: false
+    changed: false,
+    as: 'page',
+    serializedValue: 1
   });
 
   controller.set('page', 2);
@@ -165,7 +180,9 @@ test('CP - queryParamsState', function(assert) {
   assert.deepEqual(controller.get('queryParamsState.page'), {
     value: 2,
     defaultValue: 1,
-    changed: true
+    changed: true,
+    as: 'page',
+    serializedValue: 2
   });
 
   controller.setDefaultQueryParamValue('page', 2);
@@ -173,6 +190,18 @@ test('CP - queryParamsState', function(assert) {
   assert.deepEqual(controller.get('queryParamsState.page'), {
     value: 2,
     defaultValue: 2,
-    changed: false
+    changed: false,
+    as: 'page',
+    serializedValue: 2
+  });
+
+  controller.set('colors', ['red', 'blue']);
+
+  assert.deepEqual(controller.get('queryParamsState.colors'), {
+    value: ['red', 'blue'],
+    serializedValue: 'red,blue',
+    defaultValue: [],
+    changed: true,
+    as: 'colors'
   });
 });


### PR DESCRIPTION
Quick attempt at resolving this issue: https://github.com/offirgolan/ember-parachute/issues/41

The use case for us is that we're trying to generate canonical/next/prev links for fastboot rendered pages.  Unfortunately, the new router service in ember doesn't serialize values correctly when used with ember-parachute, so you can't just pass values into the `this.get('router').urlFor()` method.

Now, we're pulling the `queryParamsState` value and building an object of changed values and passing that into the `urlFor` method.