### PR TITLE
[BUGFIX] Use toArray in test since propEqual was calling firstObject on the ember array

### DIFF
--- a/tests/unit/-private/meta-test.js
+++ b/tests/unit/-private/meta-test.js
@@ -68,7 +68,7 @@ test('#queryParamsArray', function(assert) {
   ];
 
   let meta = new ParachuteMeta(dummyQpMap);
-  assert.propEqual(meta.queryParamsArray, expectedResult);
+  assert.propEqual(meta.queryParamsArray.toArray(), expectedResult);
 });
 
 test('#qpMapForController', function(assert) {

--- a/tests/unit/-private/meta-test.js
+++ b/tests/unit/-private/meta-test.js
@@ -67,8 +67,9 @@ test('#queryParamsArray', function(assert) {
     }
   ];
 
-  let meta = new ParachuteMeta(dummyQpMap);
-  assert.propEqual(meta.queryParamsArray.toArray(), expectedResult);
+  let { queryParamsArray } = new ParachuteMeta(dummyQpMap);
+  assert.propEqual(queryParamsArray.objectAt(0), expectedResult[0]);
+  assert.propEqual(queryParamsArray.objectAt(1), expectedResult[1]);
 });
 
 test('#qpMapForController', function(assert) {


### PR DESCRIPTION
Resolves #51 