### PR TITLE
docs: Add notes about setup and reset hooks not firing

### DIFF
--- a/README.md
+++ b/README.md
@@ -359,6 +359,8 @@ export default Controller.extend(myQueryParams.Mixin, {
 });
 ```
 
+> Note: If you've overridden your route's `setupController`, you must use `this._super(...arguments);` in `setupController` for the `setup` hook to fire.
+
 ### Hook - `reset`
 
 ```ts
@@ -374,6 +376,8 @@ export default Controller.extend(myQueryParams.Mixin, {
   }
 });
 ```
+
+> Note: If you've overridden your route's `resetController`, you must use `this._super(...arguments);` in `resetController` for the `reset` hook to fire.
 
 ### Events
 

--- a/tests/dummy/app/styles/app.scss
+++ b/tests/dummy/app/styles/app.scss
@@ -114,7 +114,7 @@ body {
   display: flex;
   align-items: center;
   justify-content: center;
-},
+}
 
 .help {
   position: absolute;


### PR DESCRIPTION
Took me a while to figure out why `setup` wasn't firing. Had to browse the code to see how/when it was called.