### PR TITLE
Support for Ember Engines and Typescript type annotations

### DIFF
--- a/addon/initializers/ember-parachute.js
+++ b/addon/initializers/ember-parachute.js
@@ -4,6 +4,7 @@ import ParachuteEvent from '../-private/parachute-event';
 import lookupController from '../utils/lookup-controller';
 
 const {
+  RSVP,
   run,
   assign,
   canInvoke,
@@ -70,6 +71,25 @@ export function initialize(/* application */) {
         tryInvoke(controller, 'reset', [event, isExiting]);
         sendEvent(controller, 'reset', [event, isExiting]);
       }
+    },
+
+    /**
+     * For Engines support. `transition.handlerInfos` is used to compute
+     * the query params that will be injected into a controller. In lazily
+     * loaded engines, handlerInfos maybe promises that don't contain the required
+     * information. Resolve them here to guarantee parachute can properly function.
+     *
+     * @method deserialize
+     * @param {Object} params the parameters extracted from the URL
+     * @param {Transition} transition
+     * @returns {Promise<any>} The model for this route
+     */
+    async deserialize(params, transition) {
+      await RSVP.all(
+        transition.handlerInfos.map(x => x.handlerPromise)
+      );
+
+      return this._super(params, transition);
     },
 
     /**

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,45 @@
+declare module 'ember-parachute' {
+    interface QueryParamOption<T> {
+        as?: string;
+        defaultValue: T;
+        refresh?: boolean;
+        replace?: boolean;
+        scope?: 'controller';
+        serialize?(value: T): string;
+        deserialize?(value: string): T;
+    }
+
+    type QueryParamOptions < T > = {
+        [K in keyof T]: QueryParamOption<T[K]>;
+    };
+
+    type QueryParamsState < T > = {
+        [K in keyof T]: {
+            value: T[K];
+            default: T[K];
+            changed: boolean;
+        }
+    };
+
+    export interface ParachuteEvent<T> {
+        // all changes
+        changes: T;
+        // what changed
+        changed: T;
+        queryParams: T;
+        routeName: string;
+        shouldRefresh: boolean;
+    }
+
+    export class QueryParamMixin<T> {
+        get queryParamsState(): QueryParamsState<T>;
+        setup(queryParamsChangedEvent: ParachuteEvent<T>): void;
+        queryParamsDidChange(queryParamsChangedEvent: ParachuteEvent<T>): void;
+        reset(queryParamsChangedEvent: ParachuteEvent<T>, isExiting: boolean): void;
+    }
+
+    export default class QueryParams<T> {
+        constructor(...params: Array<QueryParamOptions<T>>);
+        get Mixin(): QueryParamMixin<T> & T;
+    }
+}

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "doc": "doc",
     "test": "tests"
   },
+  "types": "index.d.ts",
   "repository": "https://github.com/offirgolan/ember-parachute",
   "bugs": "https://github.com/offirgolan/ember-parachute/issues",
   "homepage": "https://github.com/offirgolan/ember-parachute",


### PR DESCRIPTION
* Adds support for Ember Engines by waiting for lazy loaded routes to be fully loaded before initializing parachute.
* Add type annotations for typescript

Questions, comments, or concerns welcome!
