### PR TITLE
Typescript and Engines support

### DIFF
--- a/addon/initializers/ember-parachute.js
+++ b/addon/initializers/ember-parachute.js
@@ -92,9 +92,14 @@ export function initialize(/* application */) {
           return this._super(params, transition);
       }
 
+      // Save and bind the refence to the super here
+      // as this._super doesn't work in callbacks
+      // https://github.com/emberjs/ember.js/issues/15291
+      const actualSuper = this._super.bind(this);
+
       return RSVP.all(
         transition.handlerInfos.map(x => x.handlerPromise)
-      ).then(() => this._super(params, transition));
+      ).then(() => actualSuper(params, transition));
     },
 
     /**

--- a/addon/initializers/ember-parachute.js
+++ b/addon/initializers/ember-parachute.js
@@ -4,6 +4,7 @@ import ParachuteEvent from '../-private/parachute-event';
 import lookupController from '../utils/lookup-controller';
 
 const {
+  RSVP,
   run,
   assign,
   canInvoke,
@@ -70,6 +71,30 @@ export function initialize(/* application */) {
         tryInvoke(controller, 'reset', [event, isExiting]);
         sendEvent(controller, 'reset', [event, isExiting]);
       }
+    },
+
+    /**
+     * For Engines support. `transition.handlerInfos` is used to compute
+     * the query params that will be injected into a controller. In lazily
+     * loaded engines, handlerInfos may be promises that don't contain the required
+     * information. Resolve them here to guarantee parachute can properly function.
+     *
+     * @method deserialize
+     * @param {Object} params the parameters extracted from the URL
+     * @param {Transition} transition
+     * @returns {Promise<any>} The model for this route
+     */
+    deserialize(params, transition) {
+      // Check if handlers have already been loaded.
+      // If so, don't return a promise as it will result in
+      // the loading screen/state flashing.
+      if (!transition.handlerInfos.find(x => !x.handler)) {
+          return this._super(params, transition);
+      }
+
+      return RSVP.all(
+        transition.handlerInfos.map(x => x.handlerPromise)
+      ).then(() => this._super(params, transition));
     },
 
     /**

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,43 @@
+declare module 'ember-parachute' {
+    interface QueryParamOption<T> {
+        as?: string;
+        defaultValue: T;
+        refresh?: boolean;
+        replace?: boolean;
+        scope?: 'controller';
+        serialize?(value: T): string;
+        deserialize?(value: string): T;
+    }
+
+    type QueryParamOptions < T > = {
+        [K in keyof T]: QueryParamOption<T[K]>;
+    };
+
+    type QueryParamsState < T > = {
+        [K in keyof T]: {
+            value: T[K];
+            default: T[K];
+            changed: boolean;
+        }
+    };
+
+    export interface ParachuteEvent<T> {
+        changes: T;
+        changed: T;
+        queryParams: T;
+        routeName: string;
+        shouldRefresh: boolean;
+    }
+
+    export class QueryParamMixin<T> {
+        queryParamsState: QueryParamsState<T>;
+        setup(queryParamsChangedEvent: ParachuteEvent<T>): void;
+        queryParamsDidChange(queryParamsChangedEvent: ParachuteEvent<T>): void;
+        reset(queryParamsChangedEvent: ParachuteEvent<T>, isExiting: boolean): void;
+    }
+
+    export default class QueryParams<T> {
+        constructor(...params: Array<QueryParamOptions<T>>);
+        Mixin: QueryParamMixin<T> & T;
+    }
+}

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "doc": "doc",
     "test": "tests"
   },
+  "types": "index.d.ts",
   "repository": "https://github.com/offirgolan/ember-parachute",
   "bugs": "https://github.com/offirgolan/ember-parachute/issues",
   "homepage": "https://github.com/offirgolan/ember-parachute",


### PR DESCRIPTION
Follow up/correction to https://github.com/offirgolan/ember-parachute/pull/59.

Looking like the issue was with making `deserialize` always return a promise. Now a promise is only returned if the handlers have not been resolved already.

@offirgolan I wasn't able to find a difference between this implementation and the hosted dummy app. Would you mind double checking whenever you get a chance?