### PR TITLE
fix 72

### DIFF
--- a/addon/query-params.js
+++ b/addon/query-params.js
@@ -3,12 +3,10 @@ import { assign } from '@ember/polyfills';
 import { assert } from '@ember/debug';
 import { isPresent, isEmpty } from '@ember/utils';
 import { setProperties, computed, set, get } from '@ember/object';
-import Ember from 'ember';
 import { HAS_PARACHUTE, PARACHUTE_META } from './-private/symbols';
 import ParachuteMeta from './-private/parachute-meta';
 import queryParamsStateFor from './-private/state';
 
-const { NAME_KEY } = Ember;
 
 const { keys } = Object;
 
@@ -300,7 +298,6 @@ export default class QueryParams {
       }
     });
 
-    ControllerMixin[NAME_KEY] = 'Parachute';
 
     return ControllerMixin;
   }


### PR DESCRIPTION
My only hesitation with this fix is how defining `toString` on this mixin will impact consuming applications. For example, if an app uses `toString` for introspection on a controller extending the `QueryParams` mixin, will it just return `Parachute`?
I tried `toStringExtensions` and that preserved the class output, so maybe I should define that: https://emberjs.com/api/ember/3.8/classes/CoreObject/methods/toString?anchor=toString