### PR TITLE
fix: remove empty default hooks from `QueryParams`

### DIFF
--- a/addon/query-params.js
+++ b/addon/query-params.js
@@ -253,30 +253,6 @@ export default class QueryParams {
       ).readOnly(),
 
       /**
-       * Overridable hook that fires when query params change.
-       *
-       * @public
-       * @returns {void}
-       */
-      queryParamsDidChange() {},
-
-      /**
-       * Overridable hook that fires after the route calls `setupController`
-       *
-       * @public
-       * @returns {void}
-       */
-      setup() {},
-
-      /**
-       * Overridable hook that fires after the route calls `resetController`
-       *
-       * @public
-       * @returns {void}
-       */
-      reset() {},
-
-      /**
        * Reset query params to their default value. Accepts an optional array
        * of query param keys to reset.
        *

--- a/tests/acceptance/index-test.js
+++ b/tests/acceptance/index-test.js
@@ -1,0 +1,16 @@
+import { module, test } from 'qunit';
+import { visit, fillIn, waitFor } from '@ember/test-helpers';
+import { setupApplicationTest } from 'ember-qunit';
+
+module('Acceptance | index', function(hooks) {
+  setupApplicationTest(hooks);
+
+  test('visiting /', async function(assert) {
+    await visit('/');
+
+    fillIn('input[type="text"]', 'query text');
+    await waitFor('md-progress-linear')
+
+    assert.expect(0);
+  });
+});

--- a/tests/unit/decorators-test.js
+++ b/tests/unit/decorators-test.js
@@ -32,8 +32,8 @@ module('Unit | Decorators', function() {
     });
 
     test('it works', function(assert) {
-      assert.ok(typeof controller.setup === 'function');
-      assert.ok(typeof controller.reset === 'function');
+      assert.ok(typeof controller.resetQueryParams === 'function');
+      assert.ok(typeof controller.setDefaultQueryParamValue === 'function');
       assert.ok(QueryParams.metaFor(controller));
     });
   });


### PR DESCRIPTION
Because of the order that the `queryParams` mixin is applied, `queryParamsDidChange`, `setup`, and `reset` are not overrideable by methods in the controller.

The issue is visible on the [demo page](https://offirgolan.github.io/ember-parachute/); the progress bar that is supposed to appear on top of the form on `queryParamsDidChange` never shows up.

Removing the empty placeholder methods allows them to be defined in the controller, and they still work without being overriden because they are always called with `tryInvoke`.